### PR TITLE
fix: allow safe relative subfolders in filename while still blocking traversal

### DIFF
--- a/src/schemas/shared.ts
+++ b/src/schemas/shared.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { z } from 'zod';
 
 export const ZoneNameSchema = z
@@ -17,12 +16,56 @@ export const ZoneNameSchema = z
         message: 'zone name cannot end with an underscore',
     });
 
-// Reduce to the final path segment before stripping reserved characters so
-// path-traversal sequences (../, absolute paths, alt-separators) cannot escape
-// the working directory once getAbsAndEnsureDir → path.resolve runs downstream.
-// path.basename only splits on the platform's native separator, so the regex
-// must still strip backslashes for POSIX hosts receiving Windows-shaped input.
+// Allow legitimate relative subfolders (e.g. "output/data.json") while still
+// refusing to escape the working directory. Unlike a blanket path.basename(),
+// this preserves directory structure the caller asked for and only rejects
+// genuinely dangerous input, with a clear error instead of a silent rewrite:
+//   - absolute paths (POSIX "/etc/x", Windows "C:\x" or UNC "\\host\share")
+//   - ".." segments anywhere in the path
+// Backslashes are always treated as separators (not just on Windows), so a
+// Windows-shaped traversal payload can't slip through on a POSIX host by
+// switching separator style. This is the lexical half of the defense; the
+// filesystem-level half (containment + symlink-escape check against the
+// actual write target) lives in utils/files.ts's getAbsAndEnsureDir, since
+// some callers (e.g. BaseResult.save()) accept a raw path that never passes
+// through this schema at all.
+const RESERVED_CHARS = /[<>:"|?*]/g;
+const ABSOLUTE_PATH = /^\/|^[a-zA-Z]:\//;
+
 export const FilenameSchema = z
     .string()
     .min(1)
-    .transform((v) => path.basename(v).replace(/[<>:"\\|?*]/g, '_'));
+    .transform((v, ctx) => {
+        const normalized = v.replace(/\\/g, '/');
+
+        if (ABSOLUTE_PATH.test(normalized)) {
+            ctx.addIssue({
+                code: 'custom',
+                message: 'absolute paths are not allowed in filename',
+            });
+            return z.NEVER;
+        }
+
+        const segments: string[] = [];
+        for (const raw of normalized.split('/')) {
+            if (raw === '' || raw === '.') continue;
+            if (raw === '..') {
+                ctx.addIssue({
+                    code: 'custom',
+                    message: 'filename must not contain ".." path segments',
+                });
+                return z.NEVER;
+            }
+            segments.push(raw.replace(RESERVED_CHARS, '_'));
+        }
+
+        if (segments.length === 0) {
+            ctx.addIssue({
+                code: 'custom',
+                message: 'filename must not be empty',
+            });
+            return z.NEVER;
+        }
+
+        return segments.join('/');
+    });

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -43,15 +43,80 @@ export const getFilename = (
     return `brightdata_content_${Date.now()}.${format}`;
 };
 
-export const getAbsAndEnsureDir = async (filename: string) => {
+/**
+ * Resolve `filename` against `baseDir` (default: cwd) and ensure its parent
+ * directory exists — refusing to write outside `baseDir` for *relative*
+ * inputs, while still honoring an explicit absolute path.
+ *
+ * Some callers (e.g. `BaseResult.save()`) accept a raw path that never
+ * passes through `FilenameSchema`, so containment can't be assumed to have
+ * been checked already. But an absolute path is a deliberate choice by the
+ * calling code (the same trust model as calling `fs.writeFile` directly) —
+ * `.save()` is a general-purpose "write here" API, not a sanitized-filename
+ * option, and has always accepted arbitrary absolute destinations. So
+ * containment is only enforced for relative inputs, where escaping `baseDir`
+ * (e.g. "../../etc/passwd") can only mean traversal, never an intentional
+ * absolute destination. Two layers, both skipped for absolute input:
+ *  1. Lexical containment — `path.resolve` the candidate and confirm it's
+ *     still under `baseDir`. Cheap, catches the common cases, but is purely
+ *     string-based and blind to symlinks.
+ *  2. Real-path containment — after creating the parent directory, resolve
+ *     both the real (symlink-free) parent and the real base, and re-check
+ *     containment. This catches a subfolder that is (or contains) a symlink
+ *     pointing outside `baseDir`, which layer 1 cannot see.
+ */
+export const getAbsAndEnsureDir = async (
+    filename: string,
+    baseDir: string = process.cwd(),
+): Promise<string> => {
+    const resolvedBase = path.resolve(baseDir);
+    const isExplicitAbsolute = path.isAbsolute(filename);
+    const candidate = path.resolve(resolvedBase, filename);
+
+    if (
+        !isExplicitAbsolute &&
+        candidate !== resolvedBase &&
+        !candidate.startsWith(resolvedBase + path.sep)
+    ) {
+        throw new FSError(
+            `refusing to write outside the working directory: ${filename}`,
+        );
+    }
+
     try {
-        const target = path.resolve(filename);
-        await fs.mkdir(path.dirname(target), { recursive: true });
-        return target;
+        await fs.mkdir(path.dirname(candidate), { recursive: true });
     } catch (e: unknown) {
         const msg = `failed to create dirs ${filename}:`;
         throw new FSError(`${msg} ${(e as Error).message}`);
     }
+
+    if (isExplicitAbsolute) {
+        return candidate;
+    }
+
+    let realParent: string;
+    let realBase: string;
+    try {
+        [realParent, realBase] = await Promise.all([
+            fs.realpath(path.dirname(candidate)),
+            fs.realpath(resolvedBase),
+        ]);
+    } catch (e: unknown) {
+        throw new FSError(
+            `failed to resolve real path for ${filename}: ${(e as Error).message}`,
+        );
+    }
+
+    if (
+        realParent !== realBase &&
+        !realParent.startsWith(realBase + path.sep)
+    ) {
+        throw new FSError(
+            `refusing to write outside the working directory (symlink escape): ${filename}`,
+        );
+    }
+
+    return path.join(realParent, path.basename(candidate));
 };
 
 export const writeContent = async (content: string, filename: string) => {

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -9,6 +9,12 @@ import { getAbsAndEnsureDir } from '../src/utils/files';
 import { BaseResult } from '../src/models/result';
 import { bdclient } from '../src/client';
 
+// fs.symlink() typically requires Developer Mode or admin rights on Windows,
+// unrelated to whether the containment fix itself works there — skip the
+// symlink-creating tests on win32 rather than fail on an environment
+// limitation.
+const isWindows = process.platform === 'win32';
+
 describe('FilenameSchema — allows safe subfolders, rejects traversal (CWE-22)', () => {
     it('allows a single relative subfolder', () => {
         expect(assertSchema(FilenameSchema, 'output/data.json')).toBe(
@@ -169,7 +175,7 @@ describe('getAbsAndEnsureDir — filesystem-level containment (CWE-22)', () => {
         }
     });
 
-    it('throws FSError when a subfolder is a symlink escaping baseDir', async () => {
+    it.skipIf(isWindows)('throws FSError when a subfolder is a symlink escaping baseDir', async () => {
         const outsideDir = await fs.realpath(
             await fs.mkdtemp(path.join(os.tmpdir(), 'brd-sdk-outside-')),
         );
@@ -241,7 +247,7 @@ describe('saveResults — path traversal protection', () => {
         await expect(fs.stat(malicious)).rejects.toThrow();
     });
 
-    it('rejects a symlink subfolder that escapes the working directory', async () => {
+    it.skipIf(isWindows)('rejects a symlink subfolder that escapes the working directory', async () => {
         const outsideDir = await fs.realpath(
             await fs.mkdtemp(path.join(os.tmpdir(), 'brd-sdk-outside-')),
         );

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -4,40 +4,81 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import { assertSchema } from '../src/schemas/utils';
 import { FilenameSchema } from '../src/schemas/shared';
-import { ValidationError } from '../src/utils/errors';
+import { ValidationError, FSError } from '../src/utils/errors';
+import { getAbsAndEnsureDir } from '../src/utils/files';
+import { BaseResult } from '../src/models/result';
 import { bdclient } from '../src/client';
 
-describe('FilenameSchema — path traversal protection (CWE-22)', () => {
-    it('strips parent-directory traversal sequences', () => {
-        expect(assertSchema(FilenameSchema, '../../../etc/passwd')).toBe('passwd');
-        expect(assertSchema(FilenameSchema, '../etc/passwd')).toBe('passwd');
-        expect(
+describe('FilenameSchema — allows safe subfolders, rejects traversal (CWE-22)', () => {
+    it('allows a single relative subfolder', () => {
+        expect(assertSchema(FilenameSchema, 'output/data.json')).toBe(
+            'output/data.json',
+        );
+    });
+
+    it('allows deeply nested relative subfolders', () => {
+        expect(assertSchema(FilenameSchema, 'a/b/c/file.txt')).toBe(
+            'a/b/c/file.txt',
+        );
+    });
+
+    it('drops "." segments and collapses redundant slashes', () => {
+        expect(assertSchema(FilenameSchema, './output/data.json')).toBe(
+            'output/data.json',
+        );
+        expect(assertSchema(FilenameSchema, 'output//data.json')).toBe(
+            'output/data.json',
+        );
+    });
+
+    it('rejects ".." traversal segments anywhere in the path', () => {
+        expect(() => assertSchema(FilenameSchema, '../etc/passwd')).toThrow(
+            ValidationError,
+        );
+        expect(() =>
+            assertSchema(FilenameSchema, 'output/../../etc/passwd'),
+        ).toThrow(ValidationError);
+        expect(() =>
             assertSchema(
                 FilenameSchema,
                 '../../../../../../../../../../tmp/pwned.txt',
             ),
-        ).toBe('pwned.txt');
+        ).toThrow(ValidationError);
     });
 
-    it('reduces POSIX absolute paths to the basename', () => {
-        expect(assertSchema(FilenameSchema, '/tmp/pwned.txt')).toBe('pwned.txt');
-        expect(assertSchema(FilenameSchema, '/etc/passwd')).toBe('passwd');
-        expect(assertSchema(FilenameSchema, '/a/b/c/d/e/f.json')).toBe('f.json');
-    });
-
-    it('reduces nested relative paths to the basename', () => {
-        expect(assertSchema(FilenameSchema, 'output/data.json')).toBe('data.json');
-        expect(assertSchema(FilenameSchema, 'a/b/c/file.txt')).toBe('file.txt');
-    });
-
-    it('strips Windows-style separators on POSIX hosts (regex fallback)', () => {
-        // path.basename on POSIX does not split on '\\', so the regex must.
-        const result = assertSchema(
-            FilenameSchema,
-            '..\\..\\Windows\\System32\\drivers\\etc\\hosts',
+    it('rejects POSIX absolute paths', () => {
+        expect(() => assertSchema(FilenameSchema, '/tmp/pwned.txt')).toThrow(
+            ValidationError,
         );
-        expect(result).not.toContain('\\');
-        expect(result).not.toContain('/');
+        expect(() => assertSchema(FilenameSchema, '/etc/passwd')).toThrow(
+            ValidationError,
+        );
+    });
+
+    it('rejects Windows-style absolute paths (drive letter)', () => {
+        expect(() =>
+            assertSchema(FilenameSchema, 'C:\\Windows\\System32\\hosts'),
+        ).toThrow(ValidationError);
+        expect(() => assertSchema(FilenameSchema, 'C:/Windows/hosts')).toThrow(
+            ValidationError,
+        );
+    });
+
+    it('rejects UNC-style paths', () => {
+        expect(() =>
+            assertSchema(FilenameSchema, '\\\\server\\share\\file.txt'),
+        ).toThrow(ValidationError);
+    });
+
+    it('rejects Windows-style traversal on POSIX hosts (backslash treated as a separator)', () => {
+        // Backslashes are normalized to separators regardless of host OS, so a
+        // Windows-shaped payload can't slip through by switching separators.
+        expect(() =>
+            assertSchema(
+                FilenameSchema,
+                '..\\..\\Windows\\System32\\drivers\\etc\\hosts',
+            ),
+        ).toThrow(ValidationError);
     });
 
     it('preserves legitimate basenames untouched', () => {
@@ -48,14 +89,105 @@ describe('FilenameSchema — path traversal protection (CWE-22)', () => {
         expect(assertSchema(FilenameSchema, 'snapshot.csv')).toBe('snapshot.csv');
     });
 
-    it('still strips Windows-reserved characters', () => {
+    it('still strips Windows-reserved characters, per path segment', () => {
         expect(assertSchema(FilenameSchema, 'a<b>c:d"e|f?g*h.txt')).toBe(
             'a_b_c_d_e_f_g_h.txt',
+        );
+        expect(assertSchema(FilenameSchema, 'out<put/da?ta.json')).toBe(
+            'out_put/da_ta.json',
         );
     });
 
     it('rejects empty input', () => {
         expect(() => assertSchema(FilenameSchema, '')).toThrow(ValidationError);
+    });
+
+    it('rejects input that normalizes to nothing', () => {
+        expect(() => assertSchema(FilenameSchema, '.')).toThrow(ValidationError);
+        expect(() => assertSchema(FilenameSchema, '///')).toThrow(
+            ValidationError,
+        );
+    });
+});
+
+describe('getAbsAndEnsureDir — filesystem-level containment (CWE-22)', () => {
+    let baseDir: string;
+
+    beforeEach(async () => {
+        // realpath: on macOS, os.tmpdir() returns /var/folders/... but
+        // path.resolve sees through the /private/var symlink, so canonicalize
+        // here so equality checks against resolved paths work cross-platform.
+        baseDir = await fs.realpath(
+            await fs.mkdtemp(path.join(os.tmpdir(), 'brd-sdk-getabs-test-')),
+        );
+    });
+
+    afterEach(async () => {
+        await fs.rm(baseDir, { recursive: true, force: true });
+    });
+
+    it('creates nested subfolders and resolves within baseDir', async () => {
+        const target = await getAbsAndEnsureDir('a/b/c/file.txt', baseDir);
+        expect(target).toBe(path.join(baseDir, 'a', 'b', 'c', 'file.txt'));
+        await expect(fs.stat(path.join(baseDir, 'a', 'b', 'c'))).resolves.toBeDefined();
+    });
+
+    it('defaults baseDir to process.cwd() when omitted', async () => {
+        const originalCwd = process.cwd();
+        process.chdir(baseDir);
+        try {
+            const target = await getAbsAndEnsureDir('nested/file.txt');
+            expect(target).toBe(path.join(baseDir, 'nested', 'file.txt'));
+        } finally {
+            process.chdir(originalCwd);
+        }
+    });
+
+    // FilenameSchema normally blocks this before getAbsAndEnsureDir ever sees
+    // it — but BaseResult.save() (see below) accepts a raw path that never
+    // passes through the schema, so this function must refuse *relative*
+    // traversal too.
+    it('throws FSError when a raw relative path escapes baseDir via ".."', async () => {
+        await expect(
+            getAbsAndEnsureDir('../../../etc/passwd', baseDir),
+        ).rejects.toThrow(FSError);
+    });
+
+    it('honors an explicit absolute path outside baseDir (deliberate caller choice)', async () => {
+        // Unlike a relative path, an absolute input is a deliberate decision by
+        // the calling code (same trust model as fs.writeFile) — BaseResult.save()
+        // has always supported writing to an arbitrary absolute destination.
+        const outsideDir = await fs.realpath(
+            await fs.mkdtemp(path.join(os.tmpdir(), 'brd-sdk-explicit-abs-')),
+        );
+        try {
+            const explicitTarget = path.join(outsideDir, 'file.txt');
+            const target = await getAbsAndEnsureDir(explicitTarget, baseDir);
+            expect(target).toBe(explicitTarget);
+        } finally {
+            await fs.rm(outsideDir, { recursive: true, force: true });
+        }
+    });
+
+    it('throws FSError when a subfolder is a symlink escaping baseDir', async () => {
+        const outsideDir = await fs.realpath(
+            await fs.mkdtemp(path.join(os.tmpdir(), 'brd-sdk-outside-')),
+        );
+        try {
+            const linkPath = path.join(baseDir, 'escape-link');
+            await fs.symlink(outsideDir, linkPath, 'dir');
+
+            await expect(
+                getAbsAndEnsureDir('escape-link/pwned.txt', baseDir),
+            ).rejects.toThrow(FSError);
+
+            // Nothing should have been created outside baseDir.
+            await expect(
+                fs.stat(path.join(outsideDir, 'pwned.txt')),
+            ).rejects.toThrow();
+        } finally {
+            await fs.rm(outsideDir, { recursive: true, force: true });
+        }
     });
 });
 
@@ -82,45 +214,56 @@ describe('saveResults — path traversal protection', () => {
         await fs.rm(tmpDir, { recursive: true, force: true });
     });
 
-    it('keeps a ../../../tmp/<file> payload inside the working directory', async () => {
+    it('rejects a ../../../tmp/<file> traversal payload before any write', async () => {
         const sentinel = `brd-pwn-test-${Date.now()}.txt`;
         const malicious = `../../../../../../../../../../tmp/${sentinel}`;
         const escapeTarget = path.join('/tmp', sentinel);
 
-        // Ensure no pre-existing sentinel from a previous run.
         await fs.unlink(escapeTarget).catch(() => {});
 
-        const saved = await client.saveResults('payload', {
-            filename: malicious,
-            format: 'txt',
-        });
+        await expect(
+            client.saveResults('payload', { filename: malicious, format: 'txt' }),
+        ).rejects.toThrow(ValidationError);
 
-        // The escape target must not have been created.
         await expect(fs.stat(escapeTarget)).rejects.toThrow();
-
-        // The actual write landed inside our isolated tmpDir.
-        expect(saved.startsWith(tmpDir + path.sep)).toBe(true);
-        expect(path.basename(saved)).toBe(sentinel);
-
-        const content = await fs.readFile(saved, 'utf8');
-        expect(content).toBe('payload');
     });
 
-    it('reduces absolute /tmp paths to a basename in the working directory', async () => {
+    it('rejects an absolute /tmp path before any write', async () => {
         const sentinel = `absolute-pwn-${Date.now()}.txt`;
         const malicious = `/tmp/${sentinel}`;
-        const escapeTarget = `/tmp/${sentinel}`;
 
-        await fs.unlink(escapeTarget).catch(() => {});
+        await fs.unlink(malicious).catch(() => {});
 
-        const saved = await client.saveResults('payload', {
-            filename: malicious,
-            format: 'txt',
-        });
+        await expect(
+            client.saveResults('payload', { filename: malicious, format: 'txt' }),
+        ).rejects.toThrow(ValidationError);
 
-        await expect(fs.stat(escapeTarget)).rejects.toThrow();
-        expect(saved.startsWith(tmpDir + path.sep)).toBe(true);
-        expect(path.basename(saved)).toBe(sentinel);
+        await expect(fs.stat(malicious)).rejects.toThrow();
+    });
+
+    it('rejects a symlink subfolder that escapes the working directory', async () => {
+        const outsideDir = await fs.realpath(
+            await fs.mkdtemp(path.join(os.tmpdir(), 'brd-sdk-outside-')),
+        );
+        try {
+            await fs.symlink(outsideDir, path.join(tmpDir, 'escape-link'), 'dir');
+
+            // "escape-link/pwned.txt" has no ".." or absolute segment, so it
+            // passes FilenameSchema — the symlink-escape defense in
+            // getAbsAndEnsureDir is what must catch this.
+            await expect(
+                client.saveResults('payload', {
+                    filename: 'escape-link/pwned.txt',
+                    format: 'txt',
+                }),
+            ).rejects.toThrow(FSError);
+
+            await expect(
+                fs.stat(path.join(outsideDir, 'pwned.txt')),
+            ).rejects.toThrow();
+        } finally {
+            await fs.rm(outsideDir, { recursive: true, force: true });
+        }
     });
 
     it('writes legitimate basenames at the expected location', async () => {
@@ -133,4 +276,53 @@ describe('saveResults — path traversal protection', () => {
         expect(saved).toBe(path.join(tmpDir, name));
         expect(await fs.readFile(saved, 'utf8')).toBe('hello');
     });
+
+    it('creates and writes into a legitimate nested subfolder', async () => {
+        const saved = await client.saveResults('nested-hello', {
+            filename: 'reports/2026/summary.txt',
+            format: 'txt',
+        });
+
+        expect(saved).toBe(
+            path.join(tmpDir, 'reports', '2026', 'summary.txt'),
+        );
+        expect(await fs.readFile(saved, 'utf8')).toBe('nested-hello');
+    });
 });
+
+describe('BaseResult.save() — raw filepath never passes through FilenameSchema', () => {
+    let originalCwd: string;
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        originalCwd = process.cwd();
+        tmpDir = await fs.realpath(
+            await fs.mkdtemp(path.join(os.tmpdir(), 'brd-sdk-result-test-')),
+        );
+        process.chdir(tmpDir);
+    });
+
+    afterEach(async () => {
+        process.chdir(originalCwd);
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('still refuses a raw ".." traversal payload (getAbsAndEnsureDir enforces it directly)', async () => {
+        const result = new BaseResult({ success: true, data: { ok: true } });
+        const sentinel = `brd-result-pwn-${Date.now()}.json`;
+
+        await expect(
+            result.save(`../../../../../../../../../../tmp/${sentinel}`),
+        ).rejects.toThrow(FSError);
+
+        await expect(fs.stat(path.join('/tmp', sentinel))).rejects.toThrow();
+    });
+
+    it('writes a legitimate nested path', async () => {
+        const result = new BaseResult({ success: true, data: { ok: true } });
+        const saved = await result.save('out/nested-result.json');
+
+        expect(saved).toBe(path.join(tmpDir, 'out', 'nested-result.json'));
+    });
+});
+


### PR DESCRIPTION
## Summary

Follow-up to the path-traversal fix (CWE-22) already on `main`. That fix reduced *any* `filename` to its bare basename via `path.basename()` — safe, but more aggressive than necessary: it also stripped legitimate relative subfolders developers commonly use (e.g. `filename: 'output/data.json'`), even though those never posed a traversal risk. Since that basename-only behavior was never published to npm, this PR is what users will actually see as the shipped behavior.

## What changed

**`FilenameSchema`** ([src/schemas/shared.ts](https://github.com/brightdata/sdk-js/blob/main/src/schemas/shared.ts)) — now allows relative subfolder segments (`output/data.json`, `a/b/c/file.txt`), and instead explicitly rejects, with a clear `ValidationError` (not a silent rewrite):
- `".."` segments anywhere in the path
- absolute paths — POSIX (`/etc/x`), Windows (`C:\x`), UNC (`\\host\share`)

Backslashes are always treated as separators (not just on Windows), so a Windows-shaped traversal payload can't slip through on a POSIX host by switching separator style.

**`getAbsAndEnsureDir`** ([src/utils/files.ts](https://github.com/brightdata/sdk-js/blob/main/src/utils/files.ts)) — the single chokepoint all three write paths converge on (`saveResults`, `SnapshotAPI.download`, and `BaseResult.save()` — the last of which accepts a raw path that never passes through `FilenameSchema` at all) — now enforces containment itself rather than assuming callers already sanitized:
1. **Lexical containment**: the resolved candidate must stay under the base directory (cwd by default).
2. **Real-path containment**: after `mkdir`, re-resolve via `fs.realpath` and re-check, so a subfolder that is (or contains) a symlink pointing outside the base directory can't be used to escape it — lexical resolution alone is blind to symlinks.

Containment is only enforced for **relative** inputs. An absolute path is a deliberate choice by the calling code (same trust model as calling `fs.writeFile` directly) — `BaseResult.save()` has always supported writing to an arbitrary absolute destination (see the pre-existing `/tmp/...` test in `tests/result.test.ts`), and that's preserved unchanged.

## User-facing behavior (vs. the currently-published 1.1.0)

| Input to `filename`/`filepath` | `saveResults` / `SnapshotAPI.download` | `result.save()` |
|---|---|---|
| `'output/data.json'` (relative subfolder) | ✅ creates `output/` and writes there | ✅ same as always |
| `'../etc/passwd'`, `'output/../../x'` | ❌ `ValidationError` (clear, fails fast) | ❌ `FSError` (containment check) |
| `'/etc/passwd'`, `'C:\x'`, `'\\\\host\\share'` | ❌ `ValidationError` | ✅ honored (explicit, trusted absolute path — unchanged) |
| Subfolder that's a symlink escaping cwd | n/a (blocked earlier by schema for `..`, but a *non-`..`-shaped* symlinked folder is still caught) | ❌ `FSError` (symlink escape detected via `fs.realpath`) |

## Tests

Rewrote `tests/files.test.ts`:
- `FilenameSchema` suite for the new allow-subfolders/reject-traversal behavior.
- New dedicated `getAbsAndEnsureDir` suite: nested subfolders, relative-traversal rejection, explicit-absolute-path pass-through, symlink-escape rejection.
- Extended `saveResults` integration tests: nested subfolder write, symlink-escape rejection.
- New `BaseResult.save()` coverage for the schema-bypass path (still enforces relative-traversal/symlink protection, still honors absolute paths).
- Symlink-creating tests are skipped on Windows (`fs.symlink()` needs Developer Mode/admin there — an environment limitation, not a regression) via `it.skipIf`.

## Verification

- `sanity` (lint + typecheck): clean.
- Full suite: 396/408 passing (12 skipped — real-API integration tests).
- `build` + `smoke-dist` (ESM/CJS load from actual `dist/`): clean.
